### PR TITLE
Implement some of the suggestions / fixes.

### DIFF
--- a/sofa-bounds.cpp
+++ b/sofa-bounds.cpp
@@ -61,8 +61,8 @@ struct box a_priori_bounds(struct bb_thread_params slopes, unsigned int i){
         newbox.coord_bound_intervals[2*i+1].left = 0;
         newbox.coord_bound_intervals[2*i+1].right = 0;
 
-	x1 = ExactRational(-slopes.intermediate[i].c,slopes.intermediate[i].a);
 	x2 = ExactRational(slopes.intermediate[i].c,slopes.intermediate[i].b);
+	x1 = -x2 * ExactRational(slopes.intermediate[i].c + slopes.intermediate[i].b,slopes.intermediate[i].a);
     } else {
 	//if beta < pi/2, this is done by finding smallest width that contains the intersection of H and the butterfly set
 	//set i to value such that no angle will be skipped in next loop

--- a/sofa-bounds.cpp
+++ b/sofa-bounds.cpp
@@ -204,10 +204,11 @@ inline Nef_polygon ell_side(struct slope myslope, struct interval myinterval, in
     //because x is rational, need to multiply out by its denominator
     if (lowhi == 0) x = myinterval.left;
     else x = myinterval.right;
+    x *= mc;
 
     ci *= x.denominator();
 
-    ci -= x.numerator()*mc;
+    ci -= x.numerator();
     
     ai*=x.denominator();
     bi*=x.denominator();

--- a/sofa-bounds.cpp
+++ b/sofa-bounds.cpp
@@ -54,8 +54,8 @@ struct box a_priori_bounds(struct bb_thread_params slopes, unsigned int i){
     if (!slopes.has_final) {
 	//if beta = pi/2, this is done by fixing the u (second) coordinate for one angle at zero,
 	//and restricting the v (first) coordinate so that the intersection of the corridor with H
-	//is neither empy not disconnected
-        newbox.coord_bound_intervals[2*i+0].left = ExactRational(-slopes.intermediate[i].a,slopes.intermediate[i].b) - 1;
+	//is neither contained within another such intersection nor disconnected.
+        newbox.coord_bound_intervals[2*i+0].left = 0;
         newbox.coord_bound_intervals[2*i+0].right = ExactRational(slopes.intermediate[i].c,slopes.intermediate[i].b);
 
         newbox.coord_bound_intervals[2*i+1].left = 0;
@@ -73,17 +73,17 @@ struct box a_priori_bounds(struct bb_thread_params slopes, unsigned int i){
 
     for (j=0;j<slopes.num_intermediate;j++) {
 	//with x1,x2 determined, all corridors (except i, which has already been restricted)
-	//can be restricted to translations such that they intersect [x1,x2]X[0,1] with both wings
-	//of the corridor.
+	//can be restricted to translations such that the intersection with [x1,x2]X[0,1]
+	//is not contained within another such intersection.
 	if (j==i) continue;
 	s = ExactRational(slopes.intermediate[j].a,slopes.intermediate[j].c);
 	c = ExactRational(slopes.intermediate[j].b,slopes.intermediate[j].c);
 
-        newbox.coord_bound_intervals[2*j+0].left = -s*x2 - 1;
-        newbox.coord_bound_intervals[2*j+0].right = -s*x1 + c;
+        newbox.coord_bound_intervals[2*j+0].left = -s*x2 + (1-s) * s/c;
+        newbox.coord_bound_intervals[2*j+0].right = -s*x1 + c - 1;
 
-	newbox.coord_bound_intervals[2*j+1].left = c*x1 - 1;
-        newbox.coord_bound_intervals[2*j+1].right = c*x2 + s;
+        newbox.coord_bound_intervals[2*j+1].left = c*x1 + (1-c) * c/s;
+        newbox.coord_bound_intervals[2*j+1].right = c*x2 + s - 1;
     }
     newbox.depth = 0;
 

--- a/sofa-bounds.cpp
+++ b/sofa-bounds.cpp
@@ -251,20 +251,20 @@ Nef_polygon rotated_ell(struct slope myslope, struct interval xb, struct interva
         return N1.join(N2);
 
         case 3:
-        N1 = ell_side(myslope,xb,0,0,0,0).intersection(ell_side(myslope,xb,0,0,1,1)).intersection(ell_side(myslope,yb,1,0,1,1)); //left arm bottom
-        N2 = ell_side(myslope,xb,0,1,0,0).intersection(ell_side(myslope,xb,0,1,1,1)).intersection(ell_side(myslope,yb,1,1,1,1)); //left arm top
+        N1 = ell_side(myslope,xb,0,0,1,1).intersection(ell_side(myslope,yb,1,0,0,1)); //left arm bottom
+        N2 = ell_side(myslope,xb,0,1,0,0); //left arm top, the remaining intersections are included in the union polygon
         return N1.join(N2);
 
         case 4:
-        N3 = ell_side(myslope,yb,1,0,0,0).intersection(ell_side(myslope,yb,1,0,1,1)).intersection(ell_side(myslope,xb,0,0,1,1)); //right arm bottom
-        N4 = ell_side(myslope,yb,1,1,0,0).intersection(ell_side(myslope,yb,1,1,1,1)).intersection(ell_side(myslope,xb,0,1,1,1)); //right arm top
+        N3 = ell_side(myslope,yb,1,0,1,1).intersection(ell_side(myslope,xb,0,0,0,1)); //right arm bottom
+        N4 = ell_side(myslope,yb,1,1,0,0); //right arm top, the remaining intersections are included in the union polygon
         return N3.join(N4);
 
 
 	default:
-        N1 = ell_side(myslope,xb,0,0,0,0).intersection(ell_side(myslope,xb,0,1,1,1)).intersection(ell_side(myslope,yb,1,1,1,1)); //left arm
-        N2 = ell_side(myslope,yb,1,0,0,0).intersection(ell_side(myslope,yb,1,1,1,1)).intersection(ell_side(myslope,xb,0,1,1,1)); //right arm
-        return N1.join(N2);
+        N1 = ell_side(myslope,xb,0,1,1,1).intersection(ell_side(myslope,yb,1,1,1,1)); //outer corner
+        N2 = ell_side(myslope,xb,0,0,0,0).join(ell_side(myslope,yb,1,0,0,0)); //inner corner
+        return N1.intersection(N2);
 
     }
 


### PR DESCRIPTION
References #1.

(1) The a priori intervals are now computed correctly. This can be seen e.g. by testing `thm9-bound1.txt`, for which the first iteration should yield an upper bound of `3.829`, but in reality returned `3.518`.

(2) The a priori intervals can be improved a bit (but of course, the problem in (1) isn't reintroduced).

(3) Reusing faces speeds up the Nef polygon operations. The slightly changed polygons for the splitting index selection seem to reduce the number of iterations needed.